### PR TITLE
Fixed directory separator issue on PS Core Mac/Linux

### DIFF
--- a/Datum/Public/Resolve-Datum.ps1
+++ b/Datum/Public/Resolve-Datum.ps1
@@ -29,6 +29,7 @@ Function Resolve-Datum {
     )
 
     $Pattern = '(?<opening><%=)(?<sb>.*?)(?<closure>%>)'
+    $splitPattern = '\' + [IO.Path]::DirectorySeparatorChar
     $Depth = 0
     $MergeResult = $null
     # Walk every search path in listed order, and return datum when found at end of path
@@ -43,7 +44,7 @@ Function Resolve-Datum {
                     "`$({$index})"
                 },  @('IgnoreCase', 'SingleLine', 'MultiLine'))
         
-        $PathStack = $newSearch -split '\\'
+        $PathStack = $newSearch -split $splitPattern
         $DatumFound = Resolve-DatumPath -Node $Node -DatumStructure $DatumStructure -PathStack $PathStack -PathVariables $ArraySb
         #Stop processing further path when the Max depth is reached
         # or when you found the first value


### PR DESCRIPTION
This should fix the issue on PSCore MacOS/Linux.
I hope it does not add any bug. It was tested on MacOS X 6.0.0-rc and Win10 5.1.15063.726
However, I was not able to run the tests without lots of errors. Did not have time to look into those yet.