### PR TITLE
Ensure Data from lookup is always a hashtable

### DIFF
--- a/Datum/Private/ConvertTo-Hashtable.ps1
+++ b/Datum/Private/ConvertTo-Hashtable.ps1
@@ -9,7 +9,9 @@ function ConvertTo-Hashtable
     {
         if ($null -eq $InputObject) { return $null }
 
-        if ($InputObject -is [System.Collections.Hashtable] -or ($InputObject -is [System.Collections.Specialized.OrderedDictionary])) {
+        if ($InputObject -is [System.Collections.Hashtable] -or
+           ($InputObject -is [System.Collections.Specialized.OrderedDictionary]) -or
+           ($InputObject -is [System.Management.Automation.PSCredential])) {
             return $InputObject
         }
         elseif ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string])
@@ -20,7 +22,7 @@ function ConvertTo-Hashtable
 
             Write-Output -NoEnumerate $collection
         }
-        elseif ($InputObject -is [psobject])
+        elseif ($InputObject -is [psobject] -or $InputObject -is [SecureDatum])
         {
             $hash = @{}
 

--- a/Datum/Public/Get-FileProviderData.ps1
+++ b/Datum/Public/Get-FileProviderData.ps1
@@ -15,9 +15,9 @@ function Get-FileProviderData {
         '.psd1' { Import-PowerShellDataFile $File }
         '.json' { Get-Content -Raw $Path | ConvertFrom-Json | ConvertTo-Hashtable }
         '.yml'  { convertfrom-yaml (Get-Content -raw $Path) -ordered | ConvertTo-Hashtable }
-        '.ejson'{ Get-Content -Raw $Path | ConvertFrom-Json | ConvertTo-ProtectedDatum -UnprotectOptions $DataOptions}
-        '.eyaml'{ ConvertFrom-Yaml (Get-Content -Raw $Path) -ordered | ConvertTo-ProtectedDatum -UnprotectOptions $DataOptions}
-        '.epsd1'{ Import-PowerShellDatafile $File | ConvertTo-ProtectedDatum -UnprotectOptions $DataOptions}
+        '.ejson'{ Get-Content -Raw $Path | ConvertFrom-Json | ConvertTo-ProtectedDatum -UnprotectOptions $DataOptions | ConvertTo-Hashtable}
+        '.eyaml'{ ConvertFrom-Yaml (Get-Content -Raw $Path) -ordered | ConvertTo-ProtectedDatum -UnprotectOptions $DataOptions | ConvertTo-Hashtable}
+        '.epsd1'{ Import-PowerShellDatafile $File | ConvertTo-ProtectedDatum -UnprotectOptions $DataOptions | ConvertTo-Hashtable}
         Default { Get-Content -Raw $Path }
     }
 }


### PR DESCRIPTION
Right now, the lookup function returns data of different types, depending on the file extension - this makes it very hard to do anything with (e.g. pass into Get-DSCSplattedResource or as ConfigurationData).

The change here ensures complex data from lookup is always a hashtable (or a credential / array / simple type).

This approach resolves issue #4 - you should be able to run
```
 | ConvertTo-ProtectedDatum -UnprotectOptions $DataOptions | ConvertTo-Hashtable
```
regardless of the extension, and get the same object back.