### PR TITLE
Adding DatumProvider class

### DIFF
--- a/Datum/classes/DatumProvider.ps1
+++ b/Datum/classes/DatumProvider.ps1
@@ -1,0 +1,3 @@
+class DatumProvider {
+    hidden [bool]$IsDatumProvider = $true
+}

--- a/Datum/classes/FileProvider.ps1
+++ b/Datum/classes/FileProvider.ps1
@@ -1,4 +1,4 @@
-Class FileProvider {
+Class FileProvider : DatumProvider {
     hidden $Path
     hidden [hashtable] $Store
     hidden [hashtable] $DatumHierarchyDefinition


### PR DESCRIPTION
To identify a DatumProvider programmatically, FileProvider and all new providers can inherit from DatumProvder. This is required for example in [Get-DatumNodesRecursive](https://github.com/raandree/DscInfraSample/blob/081334f1d2cb5f3bfceaed1d58f16c9e6b8c5663/.build/DSC/ConfigData.build.ps1#L18) to distinguish between nodes and FileProviders.

Unfortunately the type name of a class defined in PowerShell [can only be used within the modules or script](https://stackoverflow.com/questions/32743812/testing-a-powershell-dsc-script-class-with-pester-unable-to-find-type-classna). Hence I have added the property 'IsDatumProvider' to achieve the same.
