### PR TITLE
Update to support single item arrays

### DIFF
--- a/Datum/Public/Merge-Datum.ps1
+++ b/Datum/Public/Merge-Datum.ps1
@@ -71,14 +71,14 @@ function Merge-Datum {
                     #--> $ref + $diff -$kop
                     if($regexPattern = $Strategy.merge_options.knockout_prefix) {
                         $regexPattern = $regexPattern.insert(0,'^')
-                        ($ReferenceDatum + $DifferenceDatum).Where{$_ -notmatch $regexPattern}
+                        Write-Output (($ReferenceDatum + $DifferenceDatum).Where{$_ -notmatch $regexPattern}) -NoEnumerate
                     }
                     else {
-                        ($ReferenceDatum + $DifferenceDatum)
+                        Write-Output ($ReferenceDatum + $DifferenceDatum) -NoEnumerate
                     }
                 }
 
-                Default { return $ReferenceDatum }
+                Default { Write-Output $ReferenceDatum -NoEnumerate; return }
             }
         }
 
@@ -96,12 +96,12 @@ function Merge-Datum {
 
                 '^UniqueKeyValTuples'  {
                     #--> $ref + $diff | ? % key in TupleKeys -> $ref[Key] -eq $diff[key] is not already int output
-                    Merge-DatumArray @MergeDatumArrayParams
+                    Write-Output (Merge-DatumArray @MergeDatumArrayParams) -NoEnumerate
                 }
 
                 '^DeepTuple|^DeepItemMergeByTuples' {
                     #--> $ref + $diff | ? % key in TupleKeys -> $ref[Key] -eq $diff[key] is merged up
-                    Merge-DatumArray @MergeDatumArrayParams
+                    Write-Output (Merge-DatumArray @MergeDatumArrayParams) -NoEnumerate
                 }
 
                 '^Sum' {
@@ -109,9 +109,10 @@ function Merge-Datum {
                     (@($DifferenceArray) + @($ReferenceArray)).Foreach{
                         $null = $MergedArray.add(([ordered]@{}+$_))
                     }
+                    Write-Output $MergedArray -NoEnumerate
                 }
 
-                Default { return $ReferenceDatum }
+                Default { Write-Output $ReferenceDatum -NoEnumerate; return }
             }
         }
     }

--- a/Datum/Public/Resolve-Datum.ps1
+++ b/Datum/Public/Resolve-Datum.ps1
@@ -31,12 +31,12 @@ Function Resolve-Datum {
 
         [int]
         $MaxDepth = $(
-                if($MxdDpth = $DatumTree.__Definition.default_lookup_options.MaxDepth) { 
-                    $MxdDpth 
-                } 
-                else {
-                    -1
-                })
+            if ($MxdDpth = $DatumTree.__Definition.default_lookup_options.MaxDepth) { 
+                $MxdDpth 
+            } 
+            else {
+                -1
+            })
     )
 
     # Manage lookup options:
@@ -84,17 +84,17 @@ Function Resolve-Datum {
     
     Write-Debug "Resolve-Datum -PropertyPath <$PropertyPath> -Node $($Node.Name)"
     # Make options an ordered case insensitive variable
-    if($options) {
+    if ($options) {
         $options = [ordered]@{} + $options
     }
         
-    if( !$DatumTree.__Definition.default_lookup_options ) {
+    if ( !$DatumTree.__Definition.default_lookup_options ) {
         $default_options = Get-MergeStrategyFromString
         Write-Verbose "  Default option not found in Datum Tree"
     }
     else {
-        if($DatumTree.__Definition.default_lookup_options -is [string]) {
-            $default_options =  $(Get-MergeStrategyFromString -MergeStrategy $DatumTree.__Definition.default_lookup_options)
+        if ($DatumTree.__Definition.default_lookup_options -is [string]) {
+            $default_options = $(Get-MergeStrategyFromString -MergeStrategy $DatumTree.__Definition.default_lookup_options)
         }
         else {
             $default_options = $DatumTree.__Definition.default_lookup_options
@@ -103,7 +103,7 @@ Function Resolve-Datum {
         Write-Verbose "  Found default options in Datum Tree of type $($default_options.Strategy)."
     }
 
-    if( $DatumTree.__Definition.lookup_options) {
+    if ( $DatumTree.__Definition.lookup_options) {
         Write-Debug "  Lookup options found."
         $lookup_options = @{} + $DatumTree.__Definition.lookup_options
     }
@@ -113,13 +113,13 @@ Function Resolve-Datum {
 
     # Transform options from string to strategy hashtable
     foreach ($optKey in ([string[]]$lookup_options.keys)) {
-        if($lookup_options[$optKey] -is [string]) {
+        if ($lookup_options[$optKey] -is [string]) {
             $lookup_options[$optKey] = Get-MergeStrategyFromString -MergeStrategy $lookup_options[$optKey]
         }
     }
 
     foreach ($optKey in ([string[]]$options.keys)) {
-        if($options[$optKey] -is [string]) {
+        if ($options[$optKey] -is [string]) {
             $options[$optKey] = Get-MergeStrategyFromString -MergeStrategy $options[$optKey]
         }
     }
@@ -130,14 +130,14 @@ Function Resolve-Datum {
     }
 
     # Add default strategy for ^.* if not present, at the end
-    if(([string[]]$Options.keys) -notcontains '^.*') {
+    if (([string[]]$Options.keys) -notcontains '^.*') {
         # Adding Default flag
-        $default_options.add('Default',$true)
-        $options.add('^.*',$default_options)
+        $default_options['Default'] = $true
+        $options.add('^.*', $default_options)
     }
 
     # Create the variable to be used as Pivot in prefix path
-    if( $Variable -and $VariableName ) {
+    if ( $Variable -and $VariableName ) {
         Set-Variable -Name $VariableName -Value $Variable -Force
     }
 
@@ -153,7 +153,8 @@ Function Resolve-Datum {
     $StartingMergeStrategy = Get-MergeStrategyFromPath -PropertyPath $PropertyPath -Strategies $options
 
     # Walk every search path in listed order, and return datum when found at end of path
-    foreach ($SearchPrefix in $PathPrefixes) { #through the hierarchy
+    foreach ($SearchPrefix in $PathPrefixes) {
+        #through the hierarchy
 
         $ArraySb = [System.Collections.ArrayList]@()
         $CurrentSearch = Join-Path $SearchPrefix $PropertyPath
@@ -162,10 +163,10 @@ Function Resolve-Datum {
         #extract script block for execution into array, replace by substition strings {0},{1}...
         $newSearch = [regex]::Replace($CurrentSearch, $Pattern, {
                 param($match)
-                    $expr = $match.groups['sb'].value
-                    $index = $ArraySb.Add($expr)
-                    "`$({$index})"
-            },  @('IgnoreCase', 'SingleLine', 'MultiLine'))
+                $expr = $match.groups['sb'].value
+                $index = $ArraySb.Add($expr)
+                "`$({$index})"
+            }, @('IgnoreCase', 'SingleLine', 'MultiLine'))
         
         $PathStack = $newSearch -split $splitPattern
         # Get value for this property path
@@ -179,7 +180,7 @@ Function Resolve-Datum {
         }
         elseif ( $DatumFound ) {
 
-            if(!$MergeResult) {
+            if (!$MergeResult) {
                 $MergeResult = $DatumFound 
             }
             else {
@@ -196,8 +197,9 @@ Function Resolve-Datum {
         #if we've reached the Maximum Depth allowed, return current result and stop further execution
         if ($Depth -eq $MaxDepth) {
             Write-Debug "  Max depth of $MaxDepth reached. Stopping."
-            return $MergeResult
+            Write-Output $MergeResult -NoEnumerate
+            return
         }
     }
-    $MergeResult
+    Write-Output $MergeResult -NoEnumerate
 }

--- a/Datum/ScriptsToProcess/Resolve-NodeProperty.ps1
+++ b/Datum/ScriptsToProcess/Resolve-NodeProperty.ps1
@@ -100,7 +100,7 @@ function Global:Resolve-NodeProperty {
     }
 
     if($result -or $NullAllowed) {
-        $result
+        Write-Output $result -NoEnumerate
     }
     else {
         throw "The lookup returned a Null value, but Null is not specified as Default. This is not allowed."

--- a/Datum/tests/Integration/assets/Demo2/Datum.yml
+++ b/Datum/tests/Integration/assets/Demo2/Datum.yml
@@ -1,3 +1,17 @@
 ResolutionPrecedence:
   - 'Locations\$($Node.Location)'
   - 'Roles\$($Node.Role)'
+  - 'Roles\All'
+
+default_lookup_options:
+  strategy: deep
+
+lookup_options:
+  Disks:
+    merge_hash: deep
+    merge_basetype_array: Sum
+    merge_hash_array: UniqueKeyValTuples
+    merge_options:
+      knockout_prefix: --
+      tuple_keys:
+        - Number

--- a/Datum/tests/Integration/assets/Demo2/Roles/All.json
+++ b/Datum/tests/Integration/assets/Demo2/Roles/All.json
@@ -1,0 +1,9 @@
+{
+  "Disks":[
+    {
+      "Number": 0,
+      "DriveLetter": "C",
+      "FS": "NTFS"
+    }
+  ]
+}

--- a/Datum/tests/Integration/assets/Demo2/Roles/SomeRole.yml
+++ b/Datum/tests/Integration/assets/Demo2/Roles/SomeRole.yml
@@ -1,4 +1,5 @@
 # SomeRole.yml
+
 Data1:
   Property11: RoleValue11
   Property12: RoleValue12
@@ -6,3 +7,11 @@ Data1:
 Data2:
   Property21: RoleValue21
   Property22: RoleValue22
+
+Disks:
+  - Number: 1
+    DriveLetter: D
+    FS: NTFS
+  - Number: 2
+    DriveLetter: E
+    FS: ReFS

--- a/Datum/tests/Integration/assets/Demo2/Roles/otherRole.yml
+++ b/Datum/tests/Integration/assets/Demo2/Roles/otherRole.yml
@@ -1,0 +1,3 @@
+Data2:
+  Property21: RoleValue21
+  Property22: RoleValue22

--- a/Datum/tests/Integration/assets/Demo2/test.ps1
+++ b/Datum/tests/Integration/assets/Demo2/test.ps1
@@ -1,0 +1,9 @@
+ipmo -Force $PSScriptRoot\..\..\..\..\..\Datum
+$Node = @{NodeName = 'SRV01'; Name = 'SRV01'; role = 'SomeRole'}
+$Node2 = @{NodeName = 'SRV02'; Name = 'SRV02'; role = 'otherRole'}
+$datum = New-DatumStructure -DefinitionFile $PSScriptRoot\Datum.yml
+$a = Lookup -DatumTree $datum -Node $Node -PropertyPath Disks
+$b = Lookup -DatumTree $datum -Node $Node2 -PropertyPath Disks
+
+$a.count
+$b.count

--- a/Datum/tests/Integration/assets/Demo3/AllNodes/Node1.yml
+++ b/Datum/tests/Integration/assets/Demo3/AllNodes/Node1.yml
@@ -1,0 +1,2 @@
+Name: Node1
+Role: SomeOtherRole

--- a/Datum/tests/Integration/assets/Demo3/AllNodes/Node2.yml
+++ b/Datum/tests/Integration/assets/Demo3/AllNodes/Node2.yml
@@ -1,0 +1,2 @@
+Name: Node2
+Role: SomeRole

--- a/Datum/tests/Integration/assets/Demo3/Datum.yml
+++ b/Datum/tests/Integration/assets/Demo3/Datum.yml
@@ -1,0 +1,16 @@
+ResolutionPrecedence:
+  - 'Roles\$($Node.Role)'
+  - 'Roles\All'
+
+default_lookup_options:
+  strategy: deep
+
+lookup_options:
+  Disks:
+    merge_hash: deep
+    merge_basetype_array: Sum
+    merge_hash_array: UniqueKeyValTuples
+    merge_options:
+      knockout_prefix: --
+      tuple_keys:
+        - Number

--- a/Datum/tests/Integration/assets/Demo3/Roles/All.json
+++ b/Datum/tests/Integration/assets/Demo3/Roles/All.json
@@ -1,0 +1,9 @@
+{
+  "Disks":[
+    {
+      "Number": 0,
+      "DriveLetter": "C",
+      "FS": "NTFS"
+    }
+  ]
+}

--- a/Datum/tests/Integration/assets/Demo3/Roles/SomeRole.yml
+++ b/Datum/tests/Integration/assets/Demo3/Roles/SomeRole.yml
@@ -1,0 +1,8 @@
+# SomeRole.yml
+Disks:
+  - Number: 1
+    DriveLetter: D
+    FS: NTFS
+  - Number: 2
+    DriveLetter: E
+    FS: ReFS

--- a/Datum/tests/Integration/demo3.tests.ps1
+++ b/Datum/tests/Integration/demo3.tests.ps1
@@ -1,0 +1,42 @@
+if ($PSScriptRoot) {
+    $here = $PSScriptRoot
+}
+else {
+    $here = Join-Path $pwd.Path '*\tests\Integration\' -Resolve
+}
+
+Write-verbose "Here: $here"
+
+import-module $here\..\..\datum.psd1 -force
+
+Describe 'Test Datum overrides' {
+    Context 'Most specific Merge behavior' {
+        BeforeAll {
+
+            $Datum = New-Datumstructure -DefinitionFile  (Join-path $here '.\assets\Demo3\Datum.yml' -Resolve)
+
+            $AllNodes = @($Datum.AllNodes.psobject.Properties | ForEach-Object {
+                $Node = $Datum.AllNodes.($_.Name)
+                (@{} + $Node)
+            })
+
+            $ConfigurationData = @{
+                AllNodes = $AllNodes
+                Datum = $Datum
+            }
+        }
+
+        $TestCases = @(
+            @{Node = 'Node1'; PropertyPath = 'Disks'; Count = 1}
+            @{Node = 'Node2'; PropertyPath = 'Disks'; Count = 3}
+
+        )
+
+        It "The count of Datum <PropertyPath> for Node <Node> should be '<Count>'." -TestCases $TestCases {
+            Param($Node,$PropertyPath,$Count)
+
+            $MyNode = $AllNodes.Where({$_.Name -eq $Node})
+            (Resolve-NodeProperty -PropertyPath $PropertyPath -Node $MyNode -DatumTree $Datum) | Should -HaveCount $Count
+        }
+    }
+}


### PR DESCRIPTION
When calling Get-FileProviderData from Resolve-DatumPath, regardless of whether -NoEnumerate is used or not. Single item arrays are presented not as arrays, rather as a single item of that particular class.

In order to work around this The Get-FileProviderData function now has a new switch -AsJsonString which honours the original type to make sure that PowerShell doesn't alter the type in transit.