### PR TITLE
Pass RSOP variables to lookup

### DIFF
--- a/Datum/Public/Get-DatumRSOP.ps1
+++ b/Datum/Public/Get-DatumRSOP.ps1
@@ -23,10 +23,10 @@ function Get-DatumRsop {
         
         $Configurations.Foreach{
             if(!$RSOPNode.contains($_)) {
-                $RSOPNode.Add($_,(Lookup $_ -DefaultValue @{}))
+                $RSOPNode.Add($_,(Lookup $_ -DefaultValue @{} -Node $Node -DatumTree $Datum))
             }
             else {
-                $RSOPNode[$_] = Lookup $_ -DefaultValue @{}
+                $RSOPNode[$_] = Lookup $_ -DefaultValue @{} -Node $Node -DatumTree $Datum
             }
         }
 


### PR DESCRIPTION
The initial configurations lookup is explicit about passing its
parameters down to Resolve-NodeProperty, but the following lookups
are not. This produces unexpected results if there is no global
variable with the default name set in Resolve-NodeProperty. While
$Node is specified here and will work, may as well be explicit.