### PR TITLE
Feature/folder support and parameterless configurations

### DIFF
--- a/Datum/Private/ConvertTo-Datum.ps1
+++ b/Datum/Private/ConvertTo-Datum.ps1
@@ -46,7 +46,7 @@ function ConvertTo-Datum
             }
         }
 
-        if ($InputObject -is [System.Collections.Hashtable] -or ($InputObject -is [System.Collections.Specialized.OrderedDictionary])) {
+        if ($InputObject -is [System.Collections.IDictionary]) { 
             $hashKeys = [string[]]$InputObject.Keys
             foreach ($Key in $hashKeys) {
                 $InputObject[$Key] = ConvertTo-Datum -InputObject $InputObject[$Key] -DatumHandlers $DatumHandlers
@@ -62,7 +62,7 @@ function ConvertTo-Datum
 
             Write-Output -NoEnumerate $collection
         }
-        elseif ($InputObject -is [psobject])
+        elseif ($InputObject -is [psobject] -or $InputObject -is [DatumProvider]) 
         {
             $hash = [ordered]@{}
 

--- a/Datum/Public/Get-FileProviderData.ps1
+++ b/Datum/Public/Get-FileProviderData.ps1
@@ -18,22 +18,29 @@ function Get-FileProviderData {
         if($script:FileProviderDataCache.ContainsKey($File.FullName) -and 
         $File.LastWriteTime -eq $script:FileProviderDataCache[$File.FullName].Metadata.LastWriteTime) {
             Write-Verbose "Getting File Provider Cache for Path: $Path"
-            $script:FileProviderDataCache[$File.FullName].Value
-        }
-        else {
+            Write-Output $script:FileProviderDataCache[$File.FullName].Value -NoEnumerate
+        } else {
             Write-Verbose "Getting File Provider Data for Path: $Path"
-            $Data = switch ($File.Extension) {
-                '.psd1' { Import-PowerShellDataFile $File           | ConvertTo-Datum -DatumHandlers $DatumHandlers }
-                '.json' { ConvertFrom-Json (Get-Content -Raw $Path) | ConvertTo-Datum -DatumHandlers $DatumHandlers }
-                '.yml'  { ConvertFrom-Yaml (Get-Content -raw $Path) -ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers }
-                
-                Default { Get-Content -Raw $Path }
+            $data = switch ($File.Extension) {
+                '.psd1' {
+                    Import-PowerShellDataFile -Path $File | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                }
+                '.json' {
+                    ConvertFrom-Json (Get-Content -Path $Path -Raw) | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                }
+                '.yml' {
+                    ConvertFrom-Yaml (Get-Content -Path $Path -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                }
+                Default {
+                    Get-Content -Path $Path -Raw
+                }
             }
+            
             $script:FileProviderDataCache[$File.FullName] = @{
                 Metadata = $File
-                Value = $Data
+                Value = $data
             }
-            $Data
+            Write-Output $data -NoEnumerate
         }
     }
 }

--- a/Datum/Public/Merge-Datum.ps1
+++ b/Datum/Public/Merge-Datum.ps1
@@ -16,13 +16,13 @@ function Merge-Datum {
     Write-Debug "Merge-Datum -StartingPath <$StartingPath>"
     $Strategy = Get-MergeStrategyFromPath -Strategies $strategies -PropertyPath $startingPath -Verbose
 
-    Write-Verbose "   Merge Strategy: @$($Strategy | COnvertto-Json)"
+    Write-Verbose "   Merge Strategy: @$($Strategy | ConvertTo-Json)"
 
     $ReferenceDatumType  = Get-DatumType -DatumObject $ReferenceDatum
     $DifferenceDatumType = Get-DatumType -DatumObject $DifferenceDatum
 
     if($ReferenceDatumType -ne $DifferenceDatumType) {
-        Write-Warning "Cannot merge different types REF:[$ReferenceDatumType] | DIFF:[$DifferenceDatumType]$($DifferenceDatum.GetType()) , returning most specific Datum."
+        Write-Warning "Cannot merge different types in path '$StartingPath' REF:[$ReferenceDatumType] | DIFF:[$DifferenceDatumType]$($DifferenceDatum.GetType()) , returning most specific Datum." 
         return $ReferenceDatum
     }
 
@@ -59,10 +59,12 @@ function Merge-Datum {
                 '^Unique'   {
                     if($regexPattern = $Strategy.merge_options.knockout_prefix) {
                         $regexPattern = $regexPattern.insert(0,'^')
-                        ($ReferenceDatum + $DifferenceDatum).Where{$_ -notmatch $regexPattern} | Select-object -Unique
+                        $result = @(($ReferenceDatum + $DifferenceDatum).Where{$_ -notmatch $regexPattern} | Select-object -Unique)
+                        Write-Output $result -NoEnumerate 
                     }
                     else {
-                        ($ReferenceDatum + $DifferenceDatum)| Select-object -Unique
+                        $result = @(($ReferenceDatum + $DifferenceDatum) | Select-Object -Unique)
+                        Write-Output $result -NoEnumerate
                     }
                     
                 }

--- a/Datum/Public/Resolve-Datum.ps1
+++ b/Datum/Public/Resolve-Datum.ps1
@@ -172,6 +172,10 @@ Function Resolve-Datum {
         # Get value for this property path
         $DatumFound = Resolve-DatumPath -Node $Node -DatumTree $DatumTree -PathStack $PathStack -PathVariables $ArraySb
 
+        if ($DatumFound -is [DatumProvider]) {
+            $DatumFound = $DatumFound.ToOrderedHashTable()
+        }
+
         Write-Debug "  Depth: $depth; Merge options = $($options.count)"
 
         #Stop processing further path at first value in 'MostSpecific' mode (called 'first' in Puppet hiera)

--- a/Datum/ScriptsToProcess/Get-DscSplattedResource.ps1
+++ b/Datum/ScriptsToProcess/Get-DscSplattedResource.ps1
@@ -19,7 +19,9 @@ function Global:Get-DscSplattedResource {
     $stringBuilder = [System.Text.StringBuilder]::new()
     $null = $stringBuilder.AppendLine("Param([hashtable]`$Parameters)")
     $null = $stringBuilder.AppendLine()
-    $null = $stringBuilder.AppendLine(" `$(`$Parameters=@{}+`$Parameters)")
+    $null = $stringBuilder.AppendLine(' if ($Parameters) {')
+    $null = $stringBuilder.AppendLine(' $($Parameters=@{}+$Parameters)')
+    $null = $stringBuilder.AppendLine(' }') 
     $null = $stringBuilder.AppendLine(" $ResourceName $ExecutionName { ")
     foreach($PropertyName in $Properties.keys) {
         $null = $stringBuilder.AppendLine("$PropertyName = `$(`$Parameters['$PropertyName'])")
@@ -31,7 +33,11 @@ function Global:Get-DscSplattedResource {
         [scriptblock]::Create($stringBuilder.ToString())
     }
     else {
-        [scriptblock]::Create($stringBuilder.ToString()).Invoke($Properties)
+        if ($Properties) {
+            [scriptblock]::Create($stringBuilder.ToString()).Invoke($Properties)
+        } else {
+            [scriptblock]::Create($stringBuilder.ToString()).Invoke()
+        }
     }
 }
 Set-Alias -Name x -Value Get-DscSplattedResource -scope Global

--- a/Datum/classes/DatumProvider.ps1
+++ b/Datum/classes/DatumProvider.ps1
@@ -1,3 +1,15 @@
 class DatumProvider {
     hidden [bool]$IsDatumProvider = $true
+
+    [hashtable]ToHashTable()
+    {
+        $result = ConvertTo-Datum -InputObject $this
+        return $result
+    }
+
+    [System.Collections.Specialized.OrderedDictionary]ToOrderedHashTable()
+    {
+        $result = ConvertTo-Datum -InputObject $this
+        return $result
+    }
 }


### PR DESCRIPTION
Retry of #53. This PR contains only the changes required. Csv support is no longer part of the PR.

-----------------

I have changed the config data of the [DscProject](https://github.com/AutomatedLab/DscWorkshop) to reflect the requirement of two projects I am working on. It should be possible to split config data in multiple files supporting a multi-level folder hierarchy.

The current version of Datum (0.0.33) does not build that config and writes these errors:
```
    Context Nodes for environment Dev
WARNING: Cannot merge different types REF:[baseType] | DIFF:[baseType_array]System.Object[] , returning most specific Datum.
      [+] DSCFile01 has a valid Configurations Setting (!$null) 319ms
WARNING: Cannot merge different types REF:[baseType] | DIFF:[baseType_array]System.Object[] , returning most specific Datum.
      [+] DSCWeb01 has a valid Configurations Setting (!$null) 78ms

    Context Nodes for environment Prod
WARNING: Cannot merge different types REF:[baseType] | DIFF:[baseType_array]System.Object[] , returning most specific Datum.
      [+] DSCFile01 has a valid Configurations Setting (!$null) 69ms
WARNING: Cannot merge different types REF:[baseType] | DIFF:[baseType_array]System.Object[] , returning most specific Datum.
```

```
WARNING: Cannot merge different types REF:[baseType] | DIFF:[baseType_array]System.Object[] , returning most specific Datum.
ERROR: The 'Ine' operator failed: Exception calling "Serialize" with "2" argument(s): "Too much recursion when traversing the object graph".
At C:\Git\DscWorkshop\.build\DSC\ConfigData.build.ps1:137 char:5
+     Where-Object Name -ne * |
+     ~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes that.
