### PR TITLE
Replacing 'tupleKeys' in 'tuple_Keys' as used in the code.

### DIFF
--- a/Datum/Private/Get-MergeStrategyFromString.ps1
+++ b/Datum/Private/Get-MergeStrategyFromString.ps1
@@ -17,7 +17,7 @@ MergeStrategy: Deep
         merge_hash_array: DeepTuple
         merge_options:
         knockout_prefix: --
-        TupleKeys:
+        Tuple_Keys:
             - Name
             - Version
 #>

--- a/Datum/Public/Merge-Datum.ps1
+++ b/Datum/Public/Merge-Datum.ps1
@@ -97,12 +97,12 @@ function Merge-Datum {
                 '^MostSpecific|^First' { return $ReferenceDatum }
 
                 '^UniqueKeyValTuples'  {
-                    #--> $ref + $diff | ? % key in TupleKeys -> $ref[Key] -eq $diff[key] is not already int output
+                    #--> $ref + $diff | ? % key in Tuple_Keys -> $ref[Key] -eq $diff[key] is not already int output
                     Write-Output (Merge-DatumArray @MergeDatumArrayParams) -NoEnumerate
                 }
 
                 '^DeepTuple|^DeepItemMergeByTuples' {
-                    #--> $ref + $diff | ? % key in TupleKeys -> $ref[Key] -eq $diff[key] is merged up
+                    #--> $ref + $diff | ? % key in Tuple_Keys -> $ref[Key] -eq $diff[key] is merged up
                     Write-Output (Merge-DatumArray @MergeDatumArrayParams) -NoEnumerate
                 }
 

--- a/Datum/docs/Merging.md
+++ b/Datum/docs/Merging.md
@@ -46,14 +46,14 @@ lookup MergeTest1\MergeHash
     #      MostSpecific
     #       --> Return $ref
     #      UniqueKeyValTuples
-    #       --> $ref + $diff | ? % key in TupleKeys -> $ref[Key] -eq $diff[key] is not already int output
+    #       --> $ref + $diff | ? % key in Tuple_Keys -> $ref[Key] -eq $diff[key] is not already int output
     #      DeepTuple
-    #       --> $ref + $diff | ? % key in TupleKeys -> $ref[Key] -eq $diff[key] is merged up
+    #       --> $ref + $diff | ? % key in Tuple_Keys -> $ref[Key] -eq $diff[key] is merged up
     #      Sum
     #       --> $ref + $diff
     #   merge_options:
     #     knockout_prefix: --
-    #     TupleKeys:
+    #     Tuple_Keys:
     #       - Name
     #       - Version
 ```

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ depp or MergeRecursively:
   merge_hash_array: DeepTuple
   merge_options:
     knockout_prefix: --
-    tupleKeys:
+    tuple_Keys:
       - Name
       - Version
 ```
@@ -756,7 +756,7 @@ lookup_options:
   SoftwareBaseline\Packages:
     merge_hash_array: DeepTuple
     merge_options:
-      TupleKeys:
+      Tuple_Keys:
         - Name
         - Version
 ```


### PR DESCRIPTION
It cost us quite some time to find out how the 'tuple_Keys' work when merging hash tables. The documentation states the wrong key name.