### PR TITLE
removing Get-SplattedResource as warned in #47

### DIFF
--- a/Datum/Datum.psd1
+++ b/Datum/Datum.psd1
@@ -50,8 +50,7 @@ RequiredModules = @(
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module.
 ScriptsToProcess = @(
-    './ScriptsToProcess/Get-DscSplattedResource.ps1'
-    ,'./ScriptsToProcess/Resolve-NodeProperty.ps1'
+    './ScriptsToProcess/Resolve-NodeProperty.ps1'
 )
 
 # Type files (.ps1xml) to be loaded when importing this module

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.36]
+### Removed
+- Get-DscSplattedResource script to process is removed and now available in the DscBuildHelpers module (Datum is not DSC specific, now it's fully decoupled)
+
 ## [0.0.35]
 ### Removed
 - ProtectedData / Data Encryption datum handler is no longer built-in (need external module `Datum.ProtectedData` available in the gallery)


### PR DESCRIPTION
Breaking change: **You will now _have to_ import-module DscBuildHelpers before compiling** from the next version (0.0.36).
Update your .build task accordingly.

Hope you're watching this repo, let me know how best to keep you up to date with similar changes.