### PR TITLE
Add support for .yaml files

### DIFF
--- a/datum/Public/Get-FileProviderData.ps1
+++ b/datum/Public/Get-FileProviderData.ps1
@@ -31,7 +31,11 @@ function Get-FileProviderData {
                 '.yml' {
                     ConvertFrom-Yaml (Get-Content -Path $Path -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
                 }
+                '.yaml' {
+                    ConvertFrom-Yaml (Get-Content -Path $Path -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                }
                 Default {
+                    Write-verbose "File extension $($File.Extension) not supported. Defaulting on RAW."
                     Get-Content -Path $Path -Raw
                 }
             }


### PR DESCRIPTION
Yaml files with the extension '.yaml' would throw errors when we tried to call New-DatumStructure.
We had to rename all our .yaml files to .yml to make it pass. It all went back to this switch where the .yaml was missing.