### PR TITLE
Fix deepTuple merges with only one tuple_key

### DIFF
--- a/datum/Private/Merge-DatumArray.ps1
+++ b/datum/Private/Merge-DatumArray.ps1
@@ -93,7 +93,9 @@ function Merge-DatumArray {
                         ([ordered]@{} + $_)
                     }
                 }
-                $null = $MergedArray.AddRange($UnMergedItems)
+                if ($UnMergedItems) {
+                    $null = $MergedArray.AddRange($UnMergedItems)
+                }
             }
 
             # UniqueByProperties


### PR DESCRIPTION
# Issue

Using a single item within tuple_keys for DeepTuple merges is running into the following exception:

```powershell
ERROR: Exception calling "AddRange" with "1" argument(s): "Collection cannot be null.
Parameter name: c"
At C:\Scripts\DSCInfraTest\BuildOutput\Modules\Datum\0.0.38\datum.psm1:839 char:35
+ ...         Write-Output (Merge-DatumArray @MergeDatumArrayParams) -NoEnu ...
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
At C:\Scripts\DSCInfraTest\.build\DSC\ConfigData.Build.ps1:128 char:1
+ task Compile_Datum_Rsop {
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
At C:\Scripts\DSCInfraTest\.Build.ps1:204 char:5
+     task . Clean_BuildOutput,
+     ~~~~~~~~~~~~~~~~~~~~~~~~~
Build FAILED. 6 tasks, 1 errors, 0 warnings 00:00:15.4375137
Merge-DatumArray : Exception calling "AddRange" with "1" argument(s): "Collection cannot be null.
Parameter name: c"
At C:\Scripts\DSCInfraTest\BuildOutput\Modules\Datum\0.0.38\datum.psm1:839 char:35
+ ...         Write-Output (Merge-DatumArray @MergeDatumArrayParams) -NoEnu ...
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Merge-DatumArray], MethodInvocationException
    + FullyQualifiedErrorId : ArgumentNullException,Merge-DatumArray
```

# Cause

Single tuple_key results in empty '$UnMergedItems' in datum/Private/Merge-DatumArray.ps1

# Fix

Checking for empty '$UnMergedItems' before doing AddRange fixes the issue.