### PR TITLE
Do not convert pscredential objects to hashtable

### DIFF
--- a/datum/Private/ConvertTo-Datum.ps1
+++ b/datum/Private/ConvertTo-Datum.ps1
@@ -62,7 +62,7 @@ function ConvertTo-Datum
 
             ,$collection
         }
-        elseif ($InputObject -is [psobject] -or $InputObject -is [DatumProvider])
+        elseif (($InputObject -is [psobject] -or $InputObject -is [DatumProvider]) -and $InputObject -isnot [pscredential])
         {
             $hash = [ordered]@{}
 


### PR DESCRIPTION
Converting pscredential into a hashtable containing user name and password does not make sense. As pscredential object's base is psobject, pscredential needs to be excluded explicitly.