### PR TITLE
Fixing issue in Merge-DatumArray and some typos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fixed issue in Merge-DatumArray where it used ArrayList.AddRange to add hashtables (each key/value pair is added as a new object),
+  where Add should have been used (each hashtable is a new object).
+
 ## [0.0.38]
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Corrected a typo and incorrect debug information
+
 ### Fixed
 
 - Fixed issue in Merge-DatumArray where it used ArrayList.AddRange to add hashtables (each key/value pair is added as a new object),

--- a/datum/Private/Compare-Hashtable.ps1
+++ b/datum/Private/Compare-Hashtable.ps1
@@ -10,7 +10,7 @@ function Compare-Hashtable {
         $Property = ($ReferenceHashtable.Keys + $DifferenceHashtable.Keys | Select-Object -Unique)
     )
 
-    Write-Debug "Compare-Hashtable -Ref @{$($ReferenceHashtable.keys -join ';') -Diff @{$($DifferenceHashtable.keys -join ';')} -Property [$($Property -join ', ')]"
+    Write-Debug "Compare-Hashtable -Ref @{$($ReferenceHashtable.keys -join ';')} -Diff @{$($DifferenceHashtable.keys -join ';')} -Property [$($Property -join ', ')]"
     #Write-Debug "REF:`r`n$($ReferenceHashtable|ConvertTo-JSON)"
     #Write-Debug "DIFF:`r`n$($DifferenceHashtable|ConvertTo-JSON)"
 
@@ -28,7 +28,7 @@ function Compare-Hashtable {
                 }
             }
             else {
-                Write-Debug "Comparing: $($ReferenceHashtable[$PropertyName]) With $($ReferenceHashtable[$PropertyName])"
+                Write-Debug "Comparing: $($ReferenceHashtable[$PropertyName]) With $($DifferenceHashtable[$PropertyName])"
                 if($ReferenceHashtable[$PropertyName] -ne $DifferenceHashtable[$PropertyName]) {
                     [PSCustomObject]@{
                         SideIndicator = '<='

--- a/datum/Private/Merge-DatumArray.ps1
+++ b/datum/Private/Merge-DatumArray.ps1
@@ -93,7 +93,17 @@ function Merge-DatumArray {
                         ([ordered]@{} + $_)
                     }
                 }
-                $null = $MergedArray.AddRange($UnMergedItems)
+                if ($null -ne $UnMergedItems)
+                {
+                    if ($UnMergedItems -is [System.Array])
+                    {
+                        $null = $MergedArray.AddRange($UnMergedItems)
+                    }
+                    else
+                    {
+                        $null = $MergedArray.Add($UnMergedItems)
+                    }
+                }
             }
 
             # UniqueByProperties


### PR DESCRIPTION
This PR fixes an issue in Merge-DatumArray where each key/value pair of a hastable would be added as a separate object to an ArrayList instead of the full hashtable as a single object. This caused issues further down the line, where it expected an array of hashtables.

It also corrects two typos