### PR TITLE
Adding Encoding parameter

### DIFF
--- a/source/Classes/FileProvider.ps1
+++ b/source/Classes/FileProvider.ps1
@@ -4,7 +4,7 @@ Class FileProvider : DatumProvider {
     hidden [hashtable] $DatumHierarchyDefinition
     hidden [hashtable] $StoreOptions
     hidden [hashtable] $DatumHandlers
-    hidden [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding] $Encoding
+    hidden [string] $Encoding
 
     FileProvider ($Path, $Store, $DatumHierarchyDefinition, $Encoding)
     {

--- a/source/Classes/FileProvider.ps1
+++ b/source/Classes/FileProvider.ps1
@@ -4,22 +4,24 @@ Class FileProvider : DatumProvider {
     hidden [hashtable] $DatumHierarchyDefinition
     hidden [hashtable] $StoreOptions
     hidden [hashtable] $DatumHandlers
+    hidden [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding] $Encoding
 
-    FileProvider ($Path,$Store,$DatumHierarchyDefinition)
+    FileProvider ($Path, $Store, $DatumHierarchyDefinition, $Encoding)
     {
         $this.Store = $Store
         $this.DatumHierarchyDefinition = $DatumHierarchyDefinition
         $this.StoreOptions = $Store.StoreOptions
         $this.Path = Get-Item $Path -ErrorAction SilentlyContinue
         $this.DatumHandlers = $DatumHierarchyDefinition.DatumHandlers
+        $this.Encoding = $Encoding
 
         $Result = Get-ChildItem $path | ForEach-Object {
             if($_.PSisContainer) {
-                $val = [scriptblock]::Create("New-DatumFileProvider -Path `"$($_.FullName)`" -StoreOptions `$this.DataOptions -DatumHierarchyDefinition `$this.DatumHierarchyDefinition")
+                $val = [scriptblock]::Create("New-DatumFileProvider -Path `"$($_.FullName)`" -StoreOptions `$this.DataOptions -DatumHierarchyDefinition `$this.DatumHierarchyDefinition -Encoding `$this.Encoding")
                 $this | Add-Member -MemberType ScriptProperty -Name $_.BaseName -Value $val
             }
             else {
-                $val = [scriptblock]::Create("Get-FileProviderData -Path `"$($_.FullName)`" -DatumHandlers `$this.DatumHandlers")
+                $val = [scriptblock]::Create("Get-FileProviderData -Path `"$($_.FullName)`" -DatumHandlers `$this.DatumHandlers -Encoding `$this.Encoding")
                 $this | Add-Member -MemberType ScriptProperty -Name $_.BaseName -Value $val
             }
         }

--- a/source/Public/Get-FileProviderData.ps1
+++ b/source/Public/Get-FileProviderData.ps1
@@ -6,7 +6,8 @@ function Get-FileProviderData {
         [AllowNull()]
         $DatumHandlers = @{},
 
-        [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding]
+        [ValidateSet('Ascii', 'BigEndianUnicode', 'Default', 'Unicode', 'UTF32', 'UTF7', 'UTF8')]
+        [string]
         $Encoding = 'Default'
     )
 

--- a/source/Public/Get-FileProviderData.ps1
+++ b/source/Public/Get-FileProviderData.ps1
@@ -4,7 +4,10 @@ function Get-FileProviderData {
         $Path,
 
         [AllowNull()]
-        $DatumHandlers = @{}
+        $DatumHandlers = @{},
+
+        [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding]
+        $Encoding = 'Default'
     )
 
     begin {
@@ -26,17 +29,17 @@ function Get-FileProviderData {
                     Import-PowerShellDataFile -Path $File | ConvertTo-Datum -DatumHandlers $DatumHandlers
                 }
                 '.json' {
-                    ConvertFrom-Json (Get-Content -Path $Path -Raw) | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                    ConvertFrom-Json (Get-Content -Path $Path -Encoding $Encoding -Raw) | ConvertTo-Datum -DatumHandlers $DatumHandlers
                 }
                 '.yml' {
-                    ConvertFrom-Yaml (Get-Content -Path $Path -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                    ConvertFrom-Yaml (Get-Content -Path $Path -Encoding $Encoding -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
                 }
                 '.yaml' {
-                    ConvertFrom-Yaml (Get-Content -Path $Path -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                    ConvertFrom-Yaml (Get-Content -Path $Path -Encoding $Encoding -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
                 }
                 Default {
                     Write-verbose "File extension $($File.Extension) not supported. Defaulting on RAW."
-                    Get-Content -Path $Path -Raw
+                    Get-Content -Path $Path -Encoding $Encoding -Raw
                 }
             }
 

--- a/source/Public/New-DatumFileProvider.ps1
+++ b/source/Public/New-DatumFileProvider.ps1
@@ -1,20 +1,22 @@
-
 function New-DatumFileProvider {
     Param(
-        
+
         [alias('DataOptions')]
         [AllowNull()]
         $Store,
-        
+
         [AllowNull()]
         $DatumHierarchyDefinition = @{},
 
-        $Path = $Store.StoreOptions.Path
+        $Path = $Store.StoreOptions.Path,
+
+        [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding]
+        $Encoding = 'Default'
     )
 
     if (!$DatumHierarchyDefinition) {
         $DatumHierarchyDefinition = @{}
     }
-    
-    [FileProvider]::new($Path, $Store,$DatumHierarchyDefinition)
+
+    [FileProvider]::new($Path, $Store, $DatumHierarchyDefinition, $Encoding)
 }

--- a/source/Public/New-DatumFileProvider.ps1
+++ b/source/Public/New-DatumFileProvider.ps1
@@ -10,7 +10,8 @@ function New-DatumFileProvider {
 
         $Path = $Store.StoreOptions.Path,
 
-        [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding]
+        [ValidateSet('Ascii', 'BigEndianUnicode', 'Default', 'Unicode', 'UTF32', 'UTF7', 'UTF8')]
+        [string]
         $Encoding = 'Default'
     )
 

--- a/source/Public/New-DatumStructure.ps1
+++ b/source/Public/New-DatumStructure.ps1
@@ -19,7 +19,8 @@ function New-DatumStructure {
         [io.fileInfo]
         $DefinitionFile,
 
-        [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding]
+        [ValidateSet('Ascii', 'BigEndianUnicode', 'Default', 'Unicode', 'UTF32', 'UTF7', 'UTF8')]
+        [string]
         $Encoding = 'Default'
     )
 


### PR DESCRIPTION
Datum is not able to deal with data that contains umlauts, like "contoso\Domänen-Benutzer" or "NT AUTORITÄT\Authentifizierte Benutzer". This PR introduces a parameter 'Encoding' for 'New-DatumStructure'. The default value is 'Default', hence this should not be a breaking change.

This change was tested in the build pipeline of:
- https://github.com/raandree/FiJea
- https://github.com/DscCommunity/DscWorkshop