### PR TITLE
Cleanup of 'Get-DatumRsop'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are included in an array.
 - Formatting in all files with VSCode formatting according to the 'settings.json' file taken from Sampler
 - Added yaml format config settings 'singleQuote' and 'bracketSpacing' and reformatted all yaml files according to the new settings.
+- Cleanup
+  - Get-DatumRsop.ps1
 
 ## [0.0.39] - 2020-09-29
 

--- a/source/Public/Get-DatumRSOP.ps1
+++ b/source/Public/Get-DatumRSOP.ps1
@@ -6,7 +6,7 @@ function Get-DatumRsop
         [hashtable]
         $Datum,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [hashtable[]]
         $AllNodes,
 

--- a/source/Public/Get-DatumRSOP.ps1
+++ b/source/Public/Get-DatumRSOP.ps1
@@ -1,50 +1,56 @@
 function Get-DatumRsop
 {
     [CmdletBinding()]
-    Param(
+    param (
+        [Parameter(Mandatory = $true)]
+        [hashtable]
         $Datum,
 
+        [Parameter()]
         [hashtable[]]
         $AllNodes,
 
+        [Parameter()]
+        [string]
         $CompositionKey = 'Configurations',
 
-        [ScriptBlock]
+        [Parameter()]
+        [scriptblock]
         $Filter = {}
     )
 
     if ($Filter.ToString() -ne ([System.Management.Automation.ScriptBlock]::Create( {})).ToString())
     {
-        Write-Verbose "Filter: $($Filter.ToString())"
+        Write-Verbose -Message "Filter: $($Filter.ToString())"
         $AllNodes = [System.Collections.Hashtable[]]$allNodes.Where($Filter)
-        Write-Verbose "Node count after applying filter: $($AllNodes.Count)"
+        Write-Verbose -Message "Node count after applying filter: $($AllNodes.Count)"
     }
 
-    foreach ($Node in $AllNodes)
+    foreach ($node in $AllNodes)
     {
-        $RSOPNode = $Node.clone()
+        $rsopNode = $node.clone()
 
-        $Configurations = Lookup $CompositionKey -Node $Node -DatumTree $Datum -DefaultValue @()
-        if ($RSOPNode.contains($CompositionKey))
+        $configurations = Lookup $CompositionKey -Node $node -DatumTree $Datum -DefaultValue @()
+        if ($rsopNode.contains($CompositionKey))
         {
-            $RSOPNode[$CompositionKey] = $Configurations
+            $rsopNode[$CompositionKey] = $configurations
         }
         else
         {
-            $RSOPNode.add($CompositionKey, $Configurations)
+            $rsopNode.Add($CompositionKey, $configurations)
         }
 
-        $Configurations.Foreach{
-            if (!$RSOPNode.contains($_))
+        $configurations.Foreach{
+            if (-not $rsopNode.Contains($_))
             {
-                $RSOPNode.Add($_, (Lookup $_ -DefaultValue @{} -Node $Node -DatumTree $Datum))
+                $rsopNode.Add($_, (Lookup -PropertyPath $_ -DefaultValue @{} -Node $node -DatumTree $Datum))
             }
             else
             {
-                $RSOPNode[$_] = Lookup $_ -DefaultValue @{} -Node $Node -DatumTree $Datum
+                $rsopNode[$_] = Lookup -PropertyPath $_ -DefaultValue @{} -Node $node -DatumTree $Datum
             }
         }
 
-        $RSOPNode
+        $rsopNode
     }
 }


### PR DESCRIPTION
Made parameter 'Datum' mandatory. Are there other parameters that should be mandatory as well?