### PR TITLE
prevent early resolving of Powershell variables by using .NET Combine

### DIFF
--- a/source/Public/Resolve-Datum.ps1
+++ b/source/Public/Resolve-Datum.ps1
@@ -182,7 +182,7 @@ function Resolve-Datum
     {
         #through the hierarchy
         $arraySb = [System.Collections.ArrayList]@()
-        $currentSearch = Join-Path -Path $searchPrefix -ChildPath $PropertyPath
+        $currentSearch = [System.IO.Path]::Combine($searchPrefix, $PropertyPath)
         Write-Verbose -Message ''
         Write-Verbose -Message " Lookup <$currentSearch> $($Node.Name)"
         #extract script block for execution into array, replace by substition strings {0},{1}...


### PR DESCRIPTION
prevent early resolving of Powershell variables by using .NET Combine instead of Join-Path

We are using code like the follwoing in the datum.yml:

ResolutionPrecedence:
 ...
  - LCM\$($ro=$Node.Role.Split('_'); $ro[0])\LCM_$($env:BuildLcmMode)_AddOn
...
  - LCM\LCM_$($env:BuildLcmMode)

In this case the original Join-Path produces an runtime error (illegal path) which can be avoid by using the .NET Combine.