### PR TITLE
Considering environment variables when calling Datum handlers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Resolve-NodeProperty.ps1
   - New-DatumFileProvider.ps1
 - Added 'GitHubConfig' to build.yml and updating main branch to main.
+- Considering environment variables when calling Datum handlers.
 
 ## [0.0.39] - 2020-09-29
 

--- a/source/Private/Invoke-DatumHandler.ps1
+++ b/source/Private/Invoke-DatumHandler.ps1
@@ -93,6 +93,8 @@ function Invoke-DatumHandler
 
                     # Populate the Command's params with what's in the Datum.yml, or from variables
                     $variables = Get-Variable
+                    $environmentVariables = dir -Path env:
+
                     foreach ($paramName in $actionCommand.Parameters.Keys)
                     {
                         if ($paramName -in $commandOptions)
@@ -103,7 +105,12 @@ function Invoke-DatumHandler
                         {
                             $actionParams."$paramName" = $var[0].Value
                         }
+                        elseif ($var = $environmentVariables.Where{ $_.Name -eq $paramName })
+                        {
+                            $actionParams."$paramName" = $var[0].Value
+                        }
                     }
+
                     $internalResult = (&$actionCommand @actionParams)
                     if ($null -eq $internalResult)
                     {


### PR DESCRIPTION
Datum was passing `CommandOptions` from the `build.yml` and variables to the Datum handler, but not yet environment variables. Environment variables are quite handy as they can be initialized in a datum task and then used within a Datum handler.

For example, when the `ProjectPath` variable is needed, its value can be stored in a environment variable using a task like this:

```powershell
param ()

task SetVariables {

    $env:ProjectPath = $projectPath

}
```