### PR TITLE
[Bug fix] Enable handlers in Resolve-Datum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bug in which `$datum` was referenced instead of `$DatumTree` that led
+  to the inability to use handlers in Resolve-Datum. Also enables nodes to have
+  multiple roles.
+
 ## [0.40.1] - 2023-04-03
 
 ### Added

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -18,5 +18,5 @@
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'
     'Sampler.GitHubTasks'       = 'latest'
-
+    'Datum.InvokeCommand'       = 'latest'
 }

--- a/source/Public/Resolve-Datum.ps1
+++ b/source/Public/Resolve-Datum.ps1
@@ -172,7 +172,7 @@ function Resolve-Datum
     $startingMergeStrategy = Get-MergeStrategyFromPath -PropertyPath $PropertyPath -Strategies $Options
 
     #Invoke datum handlers
-    $PathPrefixes = $PathPrefixes | ConvertTo-Datum -DatumHandlers $datum.__Definition.DatumHandlers
+    $PathPrefixes = $PathPrefixes | ConvertTo-Datum -DatumHandlers $DatumTree.__Definition.DatumHandlers
 
     # Walk every search path in listed order, and return datum when found at end of path
     foreach ($searchPrefix in $PathPrefixes)

--- a/tests/Integration/Demo4.tests.ps1
+++ b/tests/Integration/Demo4.tests.ps1
@@ -1,0 +1,44 @@
+using module datum
+
+$here = $PSScriptRoot
+
+Remove-Module -Name datum
+
+Describe 'Test datum overrides' {
+
+    Context 'Most specific Merge behavior' {
+
+        BeforeAll {
+            Import-Module -Name datum
+
+            $datum = New-DatumStructure -DefinitionFile (Join-Path $here '.\assets\Demo4\datum.yml' -Resolve)
+
+            $AllNodes = @($datum.AllNodes.psobject.Properties | ForEach-Object {
+                    $Node = $datum.AllNodes.($_.Name)
+                    (@{} + $Node)
+                })
+
+            $configurationData = @{
+                AllNodes = $AllNodes
+                datum    = $datum
+            }
+        }
+
+        $testCases = @(
+            @{Node = 'Node1'; PropertyPath = 'Disks'; Count = 5 }
+            @{Node = 'Node2'; PropertyPath = 'Disks'; Count = 3 }
+        )
+
+        It "The count of datum <PropertyPath> for Node <Node> should be '<Count>'." -TestCases $testCases {
+            Param($Node, $PropertyPath, $Count)
+
+            $myNode = $AllNodes.Where( { $_.Name -eq $Node })
+            (Resolve-NodeProperty -PropertyPath $PropertyPath -Node $myNode -DatumTree $datum) | Should -HaveCount $Count
+        }
+
+        It 'should return False as value' {
+            $myNode = $AllNodes.Where( { $_.Name -eq 'Node3' })
+            Lookup -PropertyPath StartVM -Node $myNode -DatumTree $datum | Should -BeFalse
+        }
+    }
+}

--- a/tests/Integration/assets/Demo4/AllNodes/Node1.yml
+++ b/tests/Integration/assets/Demo4/AllNodes/Node1.yml
@@ -1,0 +1,4 @@
+Name: Node1
+Role:
+  - RolesGalore
+  - SomeRole

--- a/tests/Integration/assets/Demo4/AllNodes/Node2.yml
+++ b/tests/Integration/assets/Demo4/AllNodes/Node2.yml
@@ -1,0 +1,2 @@
+Name: Node2
+Role: SomeRole

--- a/tests/Integration/assets/Demo4/AllNodes/Node3.yml
+++ b/tests/Integration/assets/Demo4/AllNodes/Node3.yml
@@ -1,0 +1,2 @@
+Name: Node3
+Role: YetAnotherRole

--- a/tests/Integration/assets/Demo4/Datum.yml
+++ b/tests/Integration/assets/Demo4/Datum.yml
@@ -1,0 +1,21 @@
+ResolutionPrecedence:
+  - '[x= { $Node.Role | Foreach-Object {"Roles\$_"} } =]'
+  - 'Roles\All'
+
+
+DatumHandlers:
+  Datum.InvokeCommand::InvokeCommand:
+    SkipDuringLoad: true # This does not seem to have any effect, was undocumented
+
+default_lookup_options:
+  strategy: deep
+
+lookup_options:
+  Disks:
+    merge_hash: deep
+    merge_basetype_array: Sum
+    merge_hash_array: UniqueKeyValTuples
+    merge_options:
+      knockout_prefix: --
+      tuple_keys:
+        - Number

--- a/tests/Integration/assets/Demo4/Roles/All.yml
+++ b/tests/Integration/assets/Demo4/Roles/All.yml
@@ -1,0 +1,4 @@
+Disks:
+  - Number: 0
+    DriveLetter: C
+    FS: NTFS

--- a/tests/Integration/assets/Demo4/Roles/RolesGalore.yml
+++ b/tests/Integration/assets/Demo4/Roles/RolesGalore.yml
@@ -1,0 +1,7 @@
+Disks:
+  - Number: 3
+    DriveLetter: F
+    FS: NTFS
+  - Number: 4
+    DriveLetter: G
+    FS: ReFS

--- a/tests/Integration/assets/Demo4/Roles/SomeRole.yml
+++ b/tests/Integration/assets/Demo4/Roles/SomeRole.yml
@@ -1,0 +1,7 @@
+Disks:
+  - Number: 1
+    DriveLetter: D
+    FS: NTFS
+  - Number: 2
+    DriveLetter: E
+    FS: ReFS

--- a/tests/Integration/assets/Demo4/Roles/YetAnotherRole.yml
+++ b/tests/Integration/assets/Demo4/Roles/YetAnotherRole.yml
@@ -1,0 +1,1 @@
+StartVM: false


### PR DESCRIPTION
This PR fixes an issue in Resolve-Datum. The non-existing variable `$datum` was used instead of the (what I presume) intended variable `$DatumTree`.

This change also allows nodes having multiple roles and other shenanigans in the Datum.yml by enabling handlers to actually run in Resolve-Datum. To verify this I added a new test that contains a node with multiple roles. Yes, I know it breaks with the original concept, but in practical implementations using Datum we discovered the need to manage node settings that are lists.

Either way, the bug needs fixing :)