### PR TITLE
Convert PSCustomObject to Hashtable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed how JSON datum configurations are processed
+
 ## [0.40.1] - 2023-04-03
 
 ### Added

--- a/source/Public/Get-FileProviderData.ps1
+++ b/source/Public/Get-FileProviderData.ps1
@@ -41,13 +41,13 @@ function Get-FileProviderData
             }
             '.json'
             {
-                ConvertFrom-Json -InputObject (Get-Content -Path $Path -Encoding $Encoding -Raw) | ConvertTo-Datum -DatumHandlers $DatumHandlers
+                $customObject = ConvertFrom-Json -InputObject (Get-Content -Path $Path -Encoding $Encoding -Raw)
+
+                $hash = @{}
+                $customObject.PSObject.Properties | ForEach-Object { $hash[$_.Name] = $_.Value }
+                $hash | ConvertTo-Datum -DatumHandlers $DatumHandlers
             }
-            '.yml'
-            {
-                ConvertFrom-Yaml -Yaml (Get-Content -Path $Path -Encoding $Encoding -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
-            }
-            '.yaml'
+            { $_ -in '.yml','.yaml' }
             {
                 ConvertFrom-Yaml -Yaml (Get-Content -Path $Path -Encoding $Encoding -Raw) -Ordered | ConvertTo-Datum -DatumHandlers $DatumHandlers
             }


### PR DESCRIPTION
Convert the CustomObject that ConvertFrom-Json produces to a hashtable. This implementation does not use newtonsoft.json but rather haphazardly converts the PSCustomObject to a hashtable.

The alternative approach is to take on another dependency to `newtonsoft.json` and then do `ConvertFrom-JsonNewtonsoft -String (Get-Content -Path $Path -Encoding $Encoding -Raw) | ConvertTo-Datum -DatumHandlers $DatumHandlers`