### PR TITLE
Improved error handling 'Invoke-DatumHandler'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `ConvertTo-Datum` always returns `$null` when DatumHandler returns `$false` (#139)
+- Fixed `ConvertTo-Datum` always returns `$null` when DatumHandler returns `$false` (#139).
+- `Invoke-DatumHandler` did not inform about a module load error. If a filter module cannot
+  be loaded, now datum writes a warning as the error cannot be caught.
 
 ## [0.40.1] - 2023-04-03
 

--- a/source/Private/Invoke-DatumHandler.ps1
+++ b/source/Private/Invoke-DatumHandler.ps1
@@ -76,9 +76,17 @@ function Invoke-DatumHandler
         }
 
         $filterModule, $filterName = $handler -split '::'
-        if (-not (Get-Module $filterModule))
+        if (-not (Get-Module -Name $filterModule))
         {
-            Import-Module $filterModule -Force -ErrorAction Stop
+            try
+            {
+                Import-Module $filterModule -Force -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Warning "The datum handler '$handler' could not be invoked because the module '$filterModule' could not be loaded, the result is very likely incomplete. Error: $_"
+                Write-Error "The datum handler '$handler' could not be invoked because the module '$filterModule' could not be loaded. Error: $_" -Exception $_.Exception
+            }
         }
 
         $filterCommand = Get-Command -ErrorAction SilentlyContinue ('{0}\Test-{1}Filter' -f $filterModule, $filterName)


### PR DESCRIPTION
`Invoke-DatumHandler` did not inform about a module load error. If a filter module cannot be loaded, now datum writes a warning as the error cannot be caught.