### PR TITLE
Add knockout support for Basetype Arrays and add cleanup of knockout items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added knockout support for Basetype Arrays
+
 ### Fixed
 
 - Fixed `ConvertTo-Datum` always returns `$null` when DatumHandler returns `$false` (#139)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added knockout support for Basetype Arrays
+- Added cleanup of knockout items
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added knockout support for Basetype Arrays
+- Added knockout support for basetype arrays
 - Added cleanup of knockout items
+
+### Changed
+
+- Adjusted integration tests for knockout of basetype array items and hashtables keys
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `ConvertTo-Datum` always returns `$null` when DatumHandler returns `$false` (#139)
+- Fixed PowerShell 7 compatibility of Copy-Object integration test
 
 ## [0.40.1] - 2023-04-03
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ stages:
           vmImage: 'ubuntu-latest'
         steps:
           - pwsh: |
-              dotnet tool install --global GitVersion.Tool
+              dotnet tool install --global GitVersion.Tool --version 5.*
               $gitVersionObject = dotnet-gitversion | ConvertFrom-Json
               $gitVersionObject.PSObject.Properties.ForEach{
                   Write-Host -Object "Setting Task Variable '$($_.Name)' with value '$($_.Value)'."

--- a/source/Private/Clear-DatumKnockout.ps1
+++ b/source/Private/Clear-DatumKnockout.ps1
@@ -1,0 +1,139 @@
+function Clear-DatumKnockout
+{
+    [OutputType([System.Array])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $StartingPath,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [object]
+        $ReferenceDatum,
+
+        [Parameter()]
+        [hashtable]
+        $Strategies = @{
+            '^.*' = 'MostSpecific'
+        }
+    )
+
+    Write-Debug -Message "Clear-DatumKnockout -StartingPath <$StartingPath>"
+    $strategy = Get-MergeStrategyFromPath -Strategies $Strategies -PropertyPath $startingPath -Verbose
+
+    $result = $null
+
+    $referenceDatumType = Get-DatumType -DatumObject $ReferenceDatum
+
+    if ($strategy -is [string])
+    {
+        $strategy = Get-MergeStrategyFromString -MergeStrategy $strategy
+    }
+
+    Write-Verbose -Message "   Knockout-Prefix: $($strategy.merge_options.knockout_prefix)"
+
+    switch ($referenceDatumType)
+    {
+        'hashtable'
+        {
+            if ($strategy.merge_hash -match '^MostSpecific$|^First')
+            {
+                return $ReferenceDatum
+            }
+
+            $clonedReference = [ordered]@{} + $ReferenceDatum
+
+            if ($knockoutPrefixMatcher = $strategy.merge_options.knockout_prefix)
+            {
+                foreach ($knockoutKey in ($ReferenceDatum.Keys.Where{ $_ -match $knockoutPrefixMatcher }))
+                {
+                    $clonedReference.Remove($knockoutKey)
+                }
+            }
+
+            $cleanedReference = [ordered]@{} + $clonedReference
+
+            foreach ($currentKey in $clonedReference.Keys)
+            {
+                $refHashItemValueType = Get-DatumType -DatumObject $clonedReference[$currentKey]
+
+                if ($refHashItemValueType -ne 'baseType')
+                {
+                    $cleanupParams = @{
+                        StartingPath   = Join-Path -Path $StartingPath -ChildPath $currentKey
+                        ReferenceDatum = $ReferenceDatum[$currentKey]
+                        Strategies     = $Strategies
+                    }
+                    $cleanedReference[$currentKey] = Clear-DatumKnockout @cleanupParams
+                }
+            }
+
+            return $cleanedReference
+        }
+
+        'baseType_array'
+        {
+            if ($strategy.merge_baseType_array -match '^MostSpecific$|^First')
+            {
+                return $ReferenceDatum
+            }
+
+            if ($knockoutPrefixMatcher = $strategy.merge_options.knockout_prefix)
+            {
+                $knockoutPrefixMatcher = $knockoutPrefixMatcher.insert(0, '^')
+                return (, ($ReferenceDatum.Where{ $_ -notmatch $knockoutPrefixMatcher }))
+            }
+            else
+            {
+                return $ReferenceDatum
+            }
+        }
+
+        'hash_array'
+        {
+            if ($strategy.merge_hash_array -match '^MostSpecific$|^First')
+            {
+                return $ReferenceDatum
+            }
+
+            if ($knockoutPrefixMatcher = $strategy.merge_options.knockout_prefix)
+            {
+                if ($tupleKeyNames = [string[]]$Strategy.merge_options.tuple_keys)
+                {
+                    $knockoutItems = foreach ($refItem in $ReferenceDatum)
+                    {
+                        $refItemTupleKeys = $refItem.Keys.Where{ $_ -in $tupleKeyNames }
+                        if ($refItemTupleKeys -match $knockoutPrefixMatcher)
+                        {
+                            $refItem
+                        }
+                    }
+                    foreach ($knockoutItem in $knockoutItems)
+                    {
+                        $ReferenceDatum.Remove($knockoutItem)
+                    }
+                }
+            }
+
+            $cleanedArray = [System.Collections.ArrayList]::new()
+
+            foreach ($currentItem in $ReferenceDatum)
+            {
+                $cleanupItemParams = @{
+                    StartingPath   = $StartingPath
+                    ReferenceDatum = $currentItem
+                    Strategies     = $Strategies
+                }
+                $null = $cleanedArray.Add((Clear-DatumKnockout @cleanupItemParams))
+            }
+
+            return (, $cleanedArray)
+        }
+
+        default
+        {
+            return $ReferenceDatum
+        }
+    }
+}

--- a/source/Public/Merge-Datum.ps1
+++ b/source/Public/Merge-Datum.ps1
@@ -129,16 +129,18 @@ function Merge-Datum
 
                 '^Unique'
                 {
-                    if ($regexPattern = $strategy.merge_options.knockout_prefix)
+                    if ($knockoutPrefixMatcher = $strategy.merge_options.knockout_prefix)
                     {
-                        $regexPattern = $regexPattern.insert(0, '^')
-                        $result = @(($ReferenceDatum + $DifferenceDatum).Where{ $_ -notmatch $regexPattern } | Select-Object -Unique)
-                        , $result
+                        $knockoutPrefixMatcher = $knockoutPrefixMatcher.insert(0, '^')
+                        $knockedOutItems = foreach ($item in ($ReferenceDatum.Where{ $_ -match $knockoutPrefixMatcher }))
+                        {
+                            $item -replace $knockoutPrefixMatcher
+                        }
+                        return (, (($ReferenceDatum + $DifferenceDatum).Where{ $_ -notin $knockedOutItems } | Select-Object -Unique))
                     }
                     else
                     {
-                        $result = @(($ReferenceDatum + $DifferenceDatum) | Select-Object -Unique)
-                        , $result
+                        return (, (($ReferenceDatum + $DifferenceDatum) | Select-Object -Unique))
                     }
 
                 }
@@ -146,14 +148,18 @@ function Merge-Datum
                 '^Sum|^Add'
                 {
                     #--> $ref + $diff -$kop
-                    if ($regexPattern = $strategy.merge_options.knockout_prefix)
+                    if ($knockoutPrefixMatcher = $strategy.merge_options.knockout_prefix)
                     {
-                        $regexPattern = $regexPattern.insert(0, '^')
-                        , (($ReferenceDatum + $DifferenceDatum).Where{ $_ -notMatch $regexPattern })
+                        $knockoutPrefixMatcher = $knockoutPrefixMatcher.insert(0, '^')
+                        $knockedOutItems = foreach ($item in ($ReferenceDatum.Where{ $_ -match $knockoutPrefixMatcher }))
+                        {
+                            $item -replace $knockoutPrefixMatcher
+                        }
+                        return (, (($ReferenceDatum + $DifferenceDatum).Where{ $_ -notin $knockedOutItems }))
                     }
                     else
                     {
-                        , ($ReferenceDatum + $DifferenceDatum)
+                        return (, ($ReferenceDatum + $DifferenceDatum))
                     }
                 }
 
@@ -184,13 +190,13 @@ function Merge-Datum
                 '^UniqueKeyValTuples'
                 {
                     #--> $ref + $diff | ? % key in Tuple_Keys -> $ref[Key] -eq $diff[key] is not already int output
-                    , (Merge-DatumArray @MergeDatumArrayParams)
+                    return (, (Merge-DatumArray @MergeDatumArrayParams))
                 }
 
                 '^DeepTuple|^DeepItemMergeByTuples'
                 {
                     #--> $ref + $diff | ? % key in Tuple_Keys -> $ref[Key] -eq $diff[key] is merged up
-                    , (Merge-DatumArray @MergeDatumArrayParams)
+                    return (, (Merge-DatumArray @MergeDatumArrayParams))
                 }
 
                 '^Sum'
@@ -199,12 +205,12 @@ function Merge-Datum
                     (@($DifferenceArray) + @($ReferenceArray)).Foreach{
                         $null = $MergedArray.Add(([ordered]@{} + $_))
                     }
-                    , $MergedArray
+                    return (, $MergedArray)
                 }
 
                 Default
                 {
-                    return , $ReferenceDatum
+                    return (, $ReferenceDatum)
                 }
             }
         }

--- a/source/Public/Resolve-Datum.ps1
+++ b/source/Public/Resolve-Datum.ps1
@@ -175,7 +175,7 @@ function Resolve-Datum
     $PathPrefixes = $PathPrefixes | ConvertTo-Datum -DatumHandlers $datum.__Definition.DatumHandlers
 
     # Walk every search path in listed order, and return datum when found at end of path
-    foreach ($searchPrefix in $PathPrefixes)
+    :pathPrefixLoop foreach ($searchPrefix in $PathPrefixes)
     {
         #through the hierarchy
         $arraySb = [System.Collections.ArrayList]@()
@@ -229,13 +229,19 @@ function Resolve-Datum
             }
         }
 
-        #if we've reached the Maximum Depth allowed, return current result and stop further execution
+        #if we've reached the Maximum Depth allowed, stop further execution
         if ($depth -eq $MaxDepth)
         {
             Write-Debug "  Max depth of $MaxDepth reached. Stopping."
-            , $mergeResult
-            return
+            break :pathPrefixLoop
         }
     }
-    , $mergeResult
+
+    #Remove all knockout values before returning
+    $cleanupParams = @{
+        StartingPath    = $PropertyPath
+        ReferenceDatum  = $mergeResult
+        Strategies      = $Options
+    }
+    return (, (Clear-DatumKnockout @cleanupParams))
 }

--- a/tests/Integration/Copy-Object.tests.ps1
+++ b/tests/Integration/Copy-Object.tests.ps1
@@ -33,7 +33,7 @@ InModuleScope -ModuleName Datum {
 
             $result = Copy-Object -DeepCopyObject $DeepCopyObject
 
-            ($DeepCopyObject | Get-Member -MemberType Properties).Count | Should -Be ($result | Get-Member -MemberType Properties).Count
+            ($DeepCopyObject | Get-Member -MemberType Properties -Force).Count | Should -Be ($result | Get-Member -MemberType Properties -Force).Count
         }
 
     }

--- a/tests/Integration/assets/MergeTestData/AllNodes/DSCFile01.yml
+++ b/tests/Integration/assets/MergeTestData/AllNodes/DSCFile01.yml
@@ -7,10 +7,14 @@ Location: Frankfurt
 SomeData: '[Command=Get-Random]'
 
 NetworkIpConfigurationMerged:
-  IpAddress: 192.168.10.100
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      IpAddress: 192.168.10.100
 
 NetworkIpConfigurationNonMerged:
-  IpAddress: 192.168.10.100
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      IpAddress: 192.168.10.100
 
 PSDscAllowPlainTextPassword: True
 PSDscAllowDomainUser: True

--- a/tests/Integration/assets/MergeTestData/AllNodes/DSCWeb01.yml
+++ b/tests/Integration/assets/MergeTestData/AllNodes/DSCWeb01.yml
@@ -6,16 +6,36 @@ Location: Singapore
 SomeData: '[Command=Get-Random]'
 
 NetworkIpConfigurationMerged:
-  IpAddress: 192.168.10.101
-  --Gateway: null
+  ConfigureIPv6: 2
+  --DisableNetBios: null
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      IpAddress: 192.168.10.101
+      --Gateway: null
+      Destination:
+        - --192.168.10.0/24
+        - --192.168.20.0/24
+        - --192.168.30.0/24
 
-#Knockout of array values does not work
-#WindowsFeatures:
-#  Name:
-#    - --Web-Server
+WindowsFeatures:
+  Name:
+    - --Web-Server
+    - Telnet-Server
 
 NetworkIpConfigurationNonMerged:
-  IpAddress: 192.168.10.101
+  DisableNetBios: true
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      IpAddress: 192.168.10.101
+      Destination:
+        - 192.168.92.0/24
+        - 192.168.93.0/24
+        - 192.168.94.0/24
+    - InterfaceAlias: Ethernet 2
+      Destination:
+        - 192.168.102.0/24
+        - 192.168.103.0/24
+        - 192.168.104.0/24
 
 PSDscAllowPlainTextPassword: True
 PSDscAllowDomainUser: True

--- a/tests/Integration/assets/MergeTestData/AllNodes/DSCWeb02.yml
+++ b/tests/Integration/assets/MergeTestData/AllNodes/DSCWeb02.yml
@@ -13,10 +13,14 @@ Configurations:
   - FilesAndFolders
 
 NetworkIpConfigurationMerged:
-  IpAddress: 192.168.10.102
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      IpAddress: 192.168.10.102
 
 NetworkIpConfigurationNonMerged:
-  IpAddress: 192.168.10.102
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      IpAddress: 192.168.10.102
 
 PSDscAllowPlainTextPassword: True
 PSDscAllowDomainUser: True

--- a/tests/Integration/assets/MergeTestData/Baselines/ServerBaseline.yml
+++ b/tests/Integration/assets/MergeTestData/Baselines/ServerBaseline.yml
@@ -6,5 +6,22 @@ WindowsFeatures:
   Name:
     - -Telnet-Client
 
+NetworkIpConfigurationMerged:
+  ConfigureIPv6: 0
+  DisableNetBios: true
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      Prefix: 24
+      Gateway: 192.168.20.50
+      DnsServer: 192.168.20.10
+      DisableNetbios: True
+      Destination:
+        - 192.168.10.0/24
+        - 192.168.20.0/24
+        - 192.168.30.0/24
+        - 192.168.40.0/24
+        - 192.168.50.0/24
+        - 192.168.60.0/24
+
 SecurityBase:
   Role: Baseline

--- a/tests/Integration/assets/MergeTestData/Datum.yml
+++ b/tests/Integration/assets/MergeTestData/Datum.yml
@@ -21,3 +21,13 @@ lookup_options:
     merge_hash: deep
     merge_options:
       knockout_prefix: --
+  NetworkIpConfigurationMerged\Interfaces:
+    merge_hash_array: DeepTuple
+    merge_options:
+      knockout_prefix: --
+      tuple_keys:
+        - InterfaceAlias
+  NetworkIpConfigurationMerged\Interfaces\Destination:
+    merge_basetype_array: Unique
+    merge_options:
+      knockout_prefix: --

--- a/tests/Integration/assets/MergeTestData/Roles/FileServer.yml
+++ b/tests/Integration/assets/MergeTestData/Roles/FileServer.yml
@@ -12,15 +12,22 @@ FilesAndFolders:
       Type: Directory
 
 NetworkIpConfigurationMerged:
-  Prefix: 24
-  Gateway: 192.168.10.50
-  DnsServer: 192.168.10.10
-  InterfaceAlias: Ethernet
-  DisableNetbios: True
+  ConfigureIPv6: -1
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      Prefix: 24
+      Gateway: 192.168.10.50
+      DnsServer: 192.168.10.10
+      DisableNetbios: True
+      Destination:
+        - 192.168.11.0/24
+        - 192.168.22.0/24
+        - 192.168.33.0/24
 
 NetworkIpConfigurationNonMerged:
-  Prefix: 24
-  Gateway: 192.168.10.50
-  DnsServer: 192.168.10.10
-  InterfaceAlias: Ethernet
-  DisableNetbios: True
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      Prefix: 24
+      Gateway: 192.168.10.50
+      DnsServer: 192.168.10.10
+      DisableNetbios: True

--- a/tests/Integration/assets/MergeTestData/Roles/WebServer.yml
+++ b/tests/Integration/assets/MergeTestData/Roles/WebServer.yml
@@ -7,15 +7,23 @@ WindowsFeatures:
     - Web-Server
 
 NetworkIpConfigurationMerged:
-  Prefix: 24
-  Gateway: 192.168.20.50
-  DnsServer: 192.168.20.10
-  InterfaceAlias: Ethernet
-  DisableNetbios: True
+  DisableNetBios: false
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      Prefix: 24
+      Gateway: 192.168.20.50
+      DnsServer: 192.168.20.10
+      DisableNetbios: True
+      Destination:
+        - 192.168.12.0/24
+        - 192.168.23.0/24
+        - 192.168.34.0/24
 
 NetworkIpConfigurationNonMerged:
-  Prefix: 24
-  Gateway: 192.168.20.50
-  DnsServer: 192.168.20.10
-  InterfaceAlias: Ethernet
-  DisableNetbios: True
+  ConfigureIPv6: -1
+  Interfaces:
+    - InterfaceAlias: Ethernet
+      Prefix: 24
+      Gateway: 192.168.20.50
+      DnsServer: 192.168.20.10
+      DisableNetbios: True


### PR DESCRIPTION
Fixes #127 and #128.

Gitversion fix already included for getting tests running. Branch should be rebased after PR #146 was merged.