### PR TITLE
Fix merge issues when using PowerShell on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `$ConfigurationData.Datum` from the caller's scope
   ([#138](https://github.com/gaelcolas/datum/pull/138)).
 - Fixed merge issues when using PowerShell on Linux and `\` as 
-  directory\property under `ResolutionPrecedence` and `lookup_options
+  directory\property under `ResolutionPrecedence` and `lookup_options.
+- Fixed issues running integration tests with PowerShell on Linux.
 
 ## [0.41.0] - 2026-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `$ConfigurationData.Datum` from the caller's scope
   ([#138](https://github.com/gaelcolas/datum/pull/138)).
 - Fixed merge issues when using PowerShell on Linux with `\` as a
-  property separator under `lookup_options`.
+  property separator under `ResolutionPrecedence` and
+  `lookup_options`.
 - Fixed issues running integration tests with PowerShell on Linux.
 
 ## [0.41.0] - 2026-02-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Resolve-NodeProperty` default values not resolving `$Node` and
   `$ConfigurationData.Datum` from the caller's scope
   ([#138](https://github.com/gaelcolas/datum/pull/138)).
+- Fixed merge issues when using PowerShell on Linux and `\` as 
+  directory\property under `ResolutionPrecedence` and `lookup_options
 
 ## [0.41.0] - 2026-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add integration test for conditional `ResolutionPrecedence` entry
   using an InvokeCommand expression that returns a path for some nodes
   and nothing for others.
+- Updated build pipeline to also test against Linux and MacOS
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Resolve-NodeProperty` default values not resolving `$Node` and
   `$ConfigurationData.Datum` from the caller's scope
   ([#138](https://github.com/gaelcolas/datum/pull/138)).
-- Fixed merge issues when using PowerShell on Linux and `\` as 
-  directory\property under `ResolutionPrecedence` and `lookup_options.
+- Fixed merge issues when using PowerShell on Linux with `\` as a
+  property separator under `lookup_options`.
 - Fixed issues running integration tests with PowerShell on Linux.
 
 ## [0.41.0] - 2026-02-03

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,78 @@ stages:
   - stage: Test
     dependsOn: Build
     jobs:
+      - job: test_linux
+        displayName: 'Linux'
+        timeoutInMinutes: 0
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Build Artifact'
+            inputs:
+              buildType: 'current'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
+
+          - task: PowerShell@2
+            name: test
+            displayName: 'Run Tests'
+            inputs:
+              filePath: './build.ps1'
+              arguments: '-tasks test'
+              pwsh: true
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+              testRunTitle: 'Linux'
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
+            inputs:
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverageLinux'
+              parallel: true
+
+      - job: test_macos
+        displayName: 'macOS'
+        timeoutInMinutes: 0
+        pool:
+          vmImage: 'macos-latest'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Build Artifact'
+            inputs:
+              buildType: 'current'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
+
+          - task: PowerShell@2
+            name: test
+            displayName: 'Run Tests'
+            inputs:
+              filePath: './build.ps1'
+              arguments: '-tasks test'
+              pwsh: true
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+              testRunTitle: 'MacOS'
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
+            inputs:
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverageMacOS'
+              parallel: true
+
       - job: test_windows_core
         displayName: 'Windows (PowerShell)'
         timeoutInMinutes: 0
@@ -134,6 +206,8 @@ stages:
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
         dependsOn:
+          - test_linux
+          - test_macos
           - test_windows_core
           - test_windows_ps
         pool:
@@ -153,6 +227,20 @@ stages:
               buildType: 'current'
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
+
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Linux'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageLinux'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact macOS'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageMacOS'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
 
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Windows (PS 5.1)'

--- a/source/Public/Resolve-Datum.ps1
+++ b/source/Public/Resolve-Datum.ps1
@@ -87,6 +87,9 @@ function Resolve-Datum
 
     #>
 
+    # Ensure PropertyPath uses system specific directory separator
+    $PropertyPath = $PropertyPath -replace '[\/\\]', [System.IO.Path]::DirectorySeparatorChar
+
     Write-Debug -Message "Resolve-Datum -PropertyPath <$PropertyPath> -Node $($Node.Name)"
     # Make options an ordered case insensitive variable
     if ($Options)
@@ -144,6 +147,18 @@ function Resolve-Datum
     if (-not $Options)
     {
         $Options = $lookup_options
+    }
+
+    # Ensure options' PropertyPathes use system specific directory separator
+    $clonedOptions = @{} + $Options
+    foreach ($key in $clonedOptions.Keys)
+    {
+        $keyConverted = $key -replace '[\/\\]', [System.IO.Path]::DirectorySeparatorChar
+        if ($key -ne $keyConverted)
+        {
+            $Options.Add($keyConverted, $Options.$key)
+            $Options.Remove($key)
+        }
     }
 
     # Add default strategy for ^.* if not present, at the end

--- a/source/Public/Resolve-Datum.ps1
+++ b/source/Public/Resolve-Datum.ps1
@@ -156,9 +156,9 @@ function Resolve-Datum
         $optKeyConverted = $optKey -replace '[\/\\]', [System.IO.Path]::DirectorySeparatorChar
         if ($optKey -ne $optKeyConverted)
         {
-            if ($Options.Contains($keyConverted))
+            if ($Options.Contains($optKeyConverted))
             {
-                throw "The lookup options contain duplicate path '$($keyConverted)' using different property separators ('\' and'/'). This is not allowed."
+                throw "The lookup options contain duplicate path '$($optKeyConverted)' using different property separators ('\' and'/'). This is not allowed."
             }
             $Options.Add($optKeyConverted, $Options[$optKey])
             $Options.Remove($optKey)

--- a/source/Public/Resolve-Datum.ps1
+++ b/source/Public/Resolve-Datum.ps1
@@ -149,15 +149,19 @@ function Resolve-Datum
         $Options = $lookup_options
     }
 
-    # Ensure options' PropertyPathes use system specific directory separator
+    # Ensure options' PropertyPaths use system specific directory separator
     $clonedOptions = @{} + $Options
-    foreach ($key in $clonedOptions.Keys)
+    foreach ($optKey in $clonedOptions.Keys)
     {
-        $keyConverted = $key -replace '[\/\\]', [System.IO.Path]::DirectorySeparatorChar
-        if ($key -ne $keyConverted)
+        $optKeyConverted = $optKey -replace '[\/\\]', [System.IO.Path]::DirectorySeparatorChar
+        if ($optKey -ne $optKeyConverted)
         {
-            $Options.Add($keyConverted, $Options.$key)
-            $Options.Remove($key)
+            if ($Options.Contains($keyConverted))
+            {
+                throw "The lookup options contain duplicate path '$($keyConverted)' using different property separators ('\' and'/'). This is not allowed."
+            }
+            $Options.Add($optKeyConverted, $Options[$optKey])
+            $Options.Remove($optKey)
         }
     }
 

--- a/tests/Integration/Demo3.tests.ps1
+++ b/tests/Integration/Demo3.tests.ps1
@@ -7,7 +7,7 @@ Remove-Module -Name datum
 BeforeDiscovery {
     Import-Module -Name datum
 
-    $script:datum = New-DatumStructure -DefinitionFile (Join-Path $here '.\assets\Demo3\datum.yml' -Resolve)
+    $script:datum = New-DatumStructure -DefinitionFile (Join-Path $here '.\assets\Demo3\Datum.yml' -Resolve)
 
     $script:AllNodes = @($datum.AllNodes.psobject.Properties | ForEach-Object {
             $Node = $datum.AllNodes.($_.Name)
@@ -33,7 +33,7 @@ Describe 'Test datum overrides' {
         }
         Import-Module -Name datum -Force
 
-        $script:datum = New-DatumStructure -DefinitionFile (Join-Path $PSScriptRoot '.\assets\Demo3\datum.yml' -Resolve)
+        $script:datum = New-DatumStructure -DefinitionFile (Join-Path $PSScriptRoot '.\assets\Demo3\Datum.yml' -Resolve)
         $script:AllNodes = @($script:datum.AllNodes.psobject.Properties | ForEach-Object {
             $Node = $script:datum.AllNodes.($_.Name)
             (@{} + $Node)

--- a/tests/Integration/Rsop.tests.ps1
+++ b/tests/Integration/Rsop.tests.ps1
@@ -31,7 +31,7 @@ Describe "RSOP tests based on 'MergeTestData' test data" {
 
         $rsopPath = Join-Path -Path $BuildModuleOutput -ChildPath RSOP
         $rsopWithSourcePath = Join-Path -Path $BuildModuleOutput -ChildPath RsopWithSource
-        mkdir -Path $rsopPath, $rsopWithSourcePath -Force | Out-Null
+        New-Item -ItemType Directory -Path $rsopPath, $rsopWithSourcePath -Force | Out-Null
     }
 
     Context 'Base-Type array merge behavior' {

--- a/tests/Integration/RsopProtectedDatum.tests.ps1
+++ b/tests/Integration/RsopProtectedDatum.tests.ps1
@@ -26,7 +26,7 @@ BeforeDiscovery {
     $buildOutput = if ($BuildModuleOutput) { $BuildModuleOutput } else { "$here\..\..\output" }
     $script:rsopPath = Join-Path -Path $buildOutput -ChildPath RSOP
     $script:rsopWithSourcePath = Join-Path -Path $buildOutput -ChildPath RsopWithSource
-    mkdir -Path $rsopPath, $rsopWithSourcePath -Force | Out-Null
+    New-Item -ItemType Directory -Path $rsopPath, $rsopWithSourcePath -Force | Out-Null
 }
 
 Describe "Datum Handler tests based on 'DscWorkshopConfigData' test data" {
@@ -55,7 +55,7 @@ Describe "Datum Handler tests based on 'DscWorkshopConfigData' test data" {
         $buildOutput = if ($BuildModuleOutput) { $BuildModuleOutput } else { "$PSScriptRoot\..\..\output" }
         $script:rsopPath = Join-Path -Path $buildOutput -ChildPath RSOP
         $script:rsopWithSourcePath = Join-Path -Path $buildOutput -ChildPath RsopWithSource
-        mkdir -Path $script:rsopPath, $script:rsopWithSourcePath -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:rsopPath, $script:rsopWithSourcePath -Force | Out-Null
     }
 
     Context 'Accessing credentials with the correct key' {

--- a/tests/Integration/RsopProtectedDatum.tests.ps1
+++ b/tests/Integration/RsopProtectedDatum.tests.ps1
@@ -26,7 +26,7 @@ BeforeDiscovery {
     $buildOutput = if ($BuildModuleOutput) { $BuildModuleOutput } else { "$here\..\..\output" }
     $script:rsopPath = Join-Path -Path $buildOutput -ChildPath RSOP
     $script:rsopWithSourcePath = Join-Path -Path $buildOutput -ChildPath RsopWithSource
-    New-Item -ItemType Directory -Path $rsopPath, $rsopWithSourcePath -Force | Out-Null
+    New-Item -ItemType Directory -Path $script:rsopPath, $script:rsopWithSourcePath -Force | Out-Null
 }
 
 Describe "Datum Handler tests based on 'DscWorkshopConfigData' test data" {

--- a/tests/Integration/RsopWithInvokCommandHandler.tests.ps1
+++ b/tests/Integration/RsopWithInvokCommandHandler.tests.ps1
@@ -32,7 +32,7 @@ Describe "RSOP tests based on 'MergeTestDataWithInvokCommandHandler' test data" 
 
         $rsopPath = Join-Path -Path $BuildModuleOutput -ChildPath RSOP
         $rsopWithSourcePath = Join-Path -Path $BuildModuleOutput -ChildPath RsopWithSource
-        mkdir -Path $rsopPath, $rsopWithSourcePath -Force | Out-Null
+        New-Item -ItemType Directory -Path $rsopPath, $rsopWithSourcePath -Force | Out-Null
     }
 
     Context 'Base-Type array merge behavior' {


### PR DESCRIPTION
and `\` as directory\property separator under `ResolutionPrecedence` and under `lookup_options`.

Further this PR fixes issues running integration tests within PowerShell on Linux.

Build pipeline was updated to also test against Linux and MacOS for testing these changes.

Fixes https://github.com/gaelcolas/datum/issues/169.
Closes https://github.com/gaelcolas/datum/issues/170.