### PR TITLE
Fix/#173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   property separator under `ResolutionPrecedence` and
   `lookup_options`.
 - Fixed issues running integration tests with PowerShell on Linux.
+- Fixed spurious `Cannot merge different types` warning in `Merge-Datum`
+  when an empty array (`@()`) meets a populated `hash_array` on the
+  other side. An empty array is now treated as type-compatible with
+  the populated side (`baseType_array` or `hash_array`) so authors can
+  use `[]` as a clear-override or carry empty placeholder lists in
+  templates without false warnings. Genuine type mismatches (e.g.
+  `baseType_array` vs `hash_array` with content on both sides, or
+  `hashtable` vs `hash_array`) still warn as before
+  ([#173](https://github.com/gaelcolas/datum/issues/173)).
+- Added regression tests under `tests/Unit/Public/Merge-Datum.tests.ps1`
+  covering the empty-array merge cases and guarding against silencing
+  legitimate type-mismatch warnings.
 
 ## [0.41.0] - 2026-02-03
 

--- a/source/Public/Merge-Datum.ps1
+++ b/source/Public/Merge-Datum.ps1
@@ -81,6 +81,25 @@ function Merge-Datum
     $referenceDatumType = Get-DatumType -DatumObject $ReferenceDatum
     $differenceDatumType = Get-DatumType -DatumObject $DifferenceDatum
 
+    # An empty array is type-compatible with both 'baseType_array' and 'hash_array' --
+    # it has no elements whose member type could conflict. Coerce the empty side to
+    # the populated side's type so authors can use [] as a valid clear-override (and
+    # templates can carry [] for not-yet-populated lists) without triggering a
+    # spurious type-mismatch warning. See issue #173.
+    if ($referenceDatumType -ne $differenceDatumType -and
+        $referenceDatumType  -in 'baseType_array', 'hash_array' -and
+        $differenceDatumType -in 'baseType_array', 'hash_array')
+    {
+        if (@($ReferenceDatum).Count -eq 0)
+        {
+            $referenceDatumType = $differenceDatumType
+        }
+        elseif (@($DifferenceDatum).Count -eq 0)
+        {
+            $differenceDatumType = $referenceDatumType
+        }
+    }
+
     if ($referenceDatumType -ne $differenceDatumType)
     {
         Write-Warning -Message "Cannot merge different types in path '$StartingPath' REF:[$referenceDatumType] | DIFF:[$differenceDatumType]$($DifferenceDatum.GetType()) , returning most specific Datum."

--- a/tests/Unit/Public/Merge-Datum.tests.ps1
+++ b/tests/Unit/Public/Merge-Datum.tests.ps1
@@ -1,0 +1,147 @@
+using module datum
+
+Remove-Module -Name datum -ErrorAction SilentlyContinue
+
+Describe 'Merge-Datum: empty-array regression (issue #173)' {
+
+    BeforeAll {
+        Import-Module -Name datum -Force
+        $datumModule = Get-Module datum
+
+        # Minimal $script:Datum stub.
+        # Merge-Datum reads $Datum.__Definition.DatumHandlers (via Invoke-DatumHandler)
+        # and $Datum.__Definition.default_json_depth (for verbose serialization).
+        $datumStub = [pscustomobject]@{
+            __Definition = @{
+                DatumHandlers      = @{}
+                default_json_depth = 4
+            }
+        }
+
+        # Inject the stub into the module's session state. We use [scriptblock]::Create
+        # so the scriptblock is unbound and adopts the module's session state when
+        # invoked via `& $module`, ensuring the assignment hits the module's
+        # $script:Datum (not the test file's).
+        & $datumModule ([scriptblock]::Create('param($d) $script:Datum = $d')) $datumStub
+    }
+
+    Context 'Empty array vs populated array (the bug)' {
+        # These cases must NOT raise the spurious type-mismatch warning.
+        # On unpatched 0.40.x they DO, because Get-DatumType classifies @() as
+        # 'baseType_array' (since @() -as [hashtable[]] returns $null), which then
+        # falsely mismatches a populated 'hash_array' on the other side.
+
+        It 'does not warn "Cannot merge different types" when REF is @() and DIFF is hash_array' {
+            $ref  = @()
+            $diff = @(
+                @{ Name = 'Alice'; Role = 'Admin' }
+                @{ Name = 'Bob';   Role = 'User'  }
+            )
+
+            $null = Merge-Datum `
+                -StartingPath 'Users' `
+                -ReferenceDatum $ref `
+                -DifferenceDatum $diff `
+                -Strategies @{ '^.*' = 'MostSpecific' } `
+                -WarningAction SilentlyContinue `
+                -WarningVariable warnings
+
+            $warnings |
+                Where-Object { $_ -match 'Cannot merge different types' } |
+                Should -BeNullOrEmpty
+        }
+
+        It 'does not warn "Cannot merge different types" when REF is hash_array and DIFF is @()' {
+            $ref = @(
+                @{ Name = 'Alice'; Role = 'Admin' }
+                @{ Name = 'Bob';   Role = 'User'  }
+            )
+            $diff = @()
+
+            $null = Merge-Datum `
+                -StartingPath 'Users' `
+                -ReferenceDatum $ref `
+                -DifferenceDatum $diff `
+                -Strategies @{ '^.*' = 'MostSpecific' } `
+                -WarningAction SilentlyContinue `
+                -WarningVariable warnings
+
+            $warnings |
+                Where-Object { $_ -match 'Cannot merge different types' } |
+                Should -BeNullOrEmpty
+        }
+
+        It 'does not warn "Cannot merge different types" when REF is hash_array and DIFF is @() with Sum strategy' {
+            # Same as above but with a Sum strategy: empty + populated must yield populated.
+            $ref = @(
+                @{ Name = 'Alice'; Role = 'Admin' }
+                @{ Name = 'Bob';   Role = 'User'  }
+            )
+            $diff = @()
+
+            $null = Merge-Datum `
+                -StartingPath 'Users' `
+                -ReferenceDatum $ref `
+                -DifferenceDatum $diff `
+                -Strategies @{ '^.*' = @{ merge_hash_array = 'Sum' } } `
+                -WarningAction SilentlyContinue `
+                -WarningVariable warnings
+
+            $warnings |
+                Where-Object { $_ -match 'Cannot merge different types' } |
+                Should -BeNullOrEmpty
+        }
+
+        It 'does not warn "Cannot merge different types" when both REF and DIFF are empty' {
+            $null = Merge-Datum `
+                -StartingPath 'Users' `
+                -ReferenceDatum @() `
+                -DifferenceDatum @() `
+                -Strategies @{ '^.*' = 'MostSpecific' } `
+                -WarningAction SilentlyContinue `
+                -WarningVariable warnings
+
+            $warnings |
+                Where-Object { $_ -match 'Cannot merge different types' } |
+                Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Genuine type mismatch (regression guard)' {
+        # The fix must NOT silence legitimate type-mismatch warnings.
+
+        It 'still warns "Cannot merge different types" when REF is baseType_array and DIFF is hash_array' {
+            $ref  = @('alpha', 'beta')                            # baseType_array
+            $diff = @(@{ Name = 'Alice' }, @{ Name = 'Bob' })     # hash_array
+
+            $null = Merge-Datum `
+                -StartingPath 'Mixed' `
+                -ReferenceDatum $ref `
+                -DifferenceDatum $diff `
+                -Strategies @{ '^.*' = 'MostSpecific' } `
+                -WarningAction SilentlyContinue `
+                -WarningVariable warnings
+
+            $warnings |
+                Where-Object { $_ -match 'Cannot merge different types' } |
+                Should -Not -BeNullOrEmpty
+        }
+
+        It 'still warns "Cannot merge different types" when REF is hashtable and DIFF is hash_array' {
+            $ref  = @{ Name = 'Alice' }                            # hashtable
+            $diff = @(@{ Name = 'Alice' }, @{ Name = 'Bob' })      # hash_array
+
+            $null = Merge-Datum `
+                -StartingPath 'Mixed' `
+                -ReferenceDatum $ref `
+                -DifferenceDatum $diff `
+                -Strategies @{ '^.*' = 'MostSpecific' } `
+                -WarningAction SilentlyContinue `
+                -WarningVariable warnings
+
+            $warnings |
+                Where-Object { $_ -match 'Cannot merge different types' } |
+                Should -Not -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes a bug in the `Merge-Datum` function where merging an empty array with a populated array of hashes would incorrectly trigger a type-mismatch warning. Now, empty arrays are treated as type-compatible with both `baseType_array` and `hash_array`, allowing for clear-overrides and placeholder lists without spurious warnings. It also adds regression tests to ensure the fix works and that real type mismatches still produce warnings.

**Bug fix:**
- Updated `Merge-Datum` in `source/Public/Merge-Datum.ps1` so that empty arrays are treated as type-compatible with both `baseType_array` and `hash_array`, preventing false "Cannot merge different types" warnings when merging empty arrays with populated arrays of hashes. This resolves issue #173.

**Testing and validation:**
- Added comprehensive regression tests in `tests/Unit/Public/Merge-Datum.tests.ps1` to cover empty-array merge scenarios and ensure legitimate type-mismatch warnings are not suppressed.

**Documentation:**
- Updated `CHANGELOG.md` to document the bug fix and the addition of regression tests for empty-array merge cases.